### PR TITLE
Free UnivariateFinite from being a subtype of Distributions.Distribution

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -371,3 +371,9 @@ function Dist.fit(d::Type{<:UnivariateFinite},
 end
 
 
+# # BROADCASTING OVER SINGLE UNIVARIATE FINITE
+
+# This mirrors behaviour assigned Distributions.Distribution objects,
+# which allows `pdf.(d::UnivariateFinite, support(d))` to work. 
+
+Broadcast.broadcastable(d::UnivariateFinite) = Ref(d)

--- a/src/types.jl
+++ b/src/types.jl
@@ -129,14 +129,6 @@ same size as the array.
 
 # # TYPES - PLAIN AND ARRAY
 
-# extend Ditributions type hiearchy to account for non-euclidean
-# supports:
-abstract type Categorical{S<:Finite} <: Dist.ValueSupport end
-
-# not exported:
-const _UnivariateFinite_{S} =
-    Dist.Distribution{Dist.Univariate,Categorical{S}}
-
 # R - reference type <: Unsigned
 # V - type of class labels (eg, Char in `categorical(['a', 'b'])`)
 # P - raw probability type
@@ -144,7 +136,7 @@ const _UnivariateFinite_{S} =
 
 # Note that the keys of `prob_given_ref` need not exhaust all the
 # refs of all classes but will be ordered (LittleDicts preserve order)
-struct UnivariateFinite{S,V,R,P} <: _UnivariateFinite_{S}
+struct UnivariateFinite{S,V,R,P}
     scitype::Type{S}
     decoder::CategoricalDecoder{V,R}
     prob_given_ref::LittleDict{R,P,Vector{R}, Vector{P}}

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -121,6 +121,11 @@ A, S, Q, F = V[1], V[2], V[3], V[4]
     @test pdf(d, "class_1") == 0.7
 end
 
+@testset "broadcasting pdf over single UnivariateFinite object" begin
+    d = UnivariateFinite(["a", "b"], [0.1, 0.9], pool=missing);
+    @test pdf.(d, ["a", "b"]) == [0.1, 0.9]
+end 
+
 @testset "constructor arguments not categorical values" begin
     @test_throws ArgumentError UnivariateFinite(Dict('f'=>0.7, 'q'=>0.2))
     @test_throws ArgumentError UnivariateFinite(Dict('f'=>0.7, 'q'=>0.2),
@@ -276,7 +281,6 @@ end
     # v_close = [d_close, d_close]
     # @test v ≈ v_close
 end
-
 
 end # module
 


### PR DESCRIPTION
This PR removes the supertyping of `UnivariateFinite`. All overloadings of Distributions.jl methods (`pdf`, `fit`, and so forth) remain in place. 