### PR TITLE
Export UnivariateFiniteVector

### DIFF
--- a/src/CategoricalDistributions.jl
+++ b/src/CategoricalDistributions.jl
@@ -19,7 +19,7 @@ include("methods.jl")
 include("arrays.jl")
 include("arithmetic.jl")
 
-export UnivariateFinite, UnivariateFiniteArray
+export UnivariateFinite, UnivariateFiniteArray, UnivariateFiniteVector
 
 # re-eport from Distributions:
 export pdf, logpdf, support, mode


### PR DESCRIPTION
UnivariateFiniteVector is supposed to be re-exported with MLJBase.