### PR TITLE
fix issue #34

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -451,9 +451,11 @@ function _UnivariateFinite(support,
         issubset(support, _classes) ||
             error("Specified support, $support, not contained in "*
                   "specified pool, $(levels(classes)). ")
-        _support = filter(_classes) do c
-            c in support
-        end
+        idxs = getindex.(
+            Ref(CategoricalArrays.DataAPI.invrefpool(_classes)), 
+            support
+        )
+        _support = _classes[idxs] 
     end
 
     # calls core method:

--- a/test/types.jl
+++ b/test/types.jl
@@ -7,6 +7,7 @@ using StableRNGs
 using FillArrays
 using ScientificTypes
 import Random
+import CategoricalDistributions: classes
 
 # coverage of constructor testing is expanded in the other test files
 
@@ -35,6 +36,20 @@ end
     supp = ["class1", "class2"]
 
     UnivariateFinite(supp, probs, pool=missing, augment=true);
+
+    # construction from pool and support does not 
+    # consist of categorical elements (See issue #34)
+    v = categorical(["x", "x", "y", "z", "y", "z", "p"])
+    probs1 = [0.1, 0.2, 0.7]
+    probs2 = [0.1 0.2 0.7; 0.5 0.2 0.3; 0.8 0.1 0.1]
+    unf1 = UnivariateFinite(["y", "x", "z"], probs1, pool=v)
+    unf2 = UnivariateFinite(["y", "x", "z"], probs2, pool=v)
+    @test CategoricalArrays.pool(classes(unf1)) == CategoricalArrays.pool(v)
+    @test CategoricalArrays.pool(classes(unf2)) == CategoricalArrays.pool(v)
+    @test pdf.(unf1, ["y", "x", "z"]) == probs1
+    @test pdf.(unf2, "y") == probs2[:, 1]
+    @test pdf.(unf2, "x") == probs2[:, 2]
+    @test pdf.(unf2, "z") == probs2[:, 3]
 
     # dimension mismatches:
     badprobs = rand(rng, 40, 3)


### PR DESCRIPTION
Resolves #34

```julia
julia> using CategoricalDistributions, MLJBase

julia> v = categorical(["x", "x", "y", "z", "y", "z"])
6-element CategoricalArrays.CategoricalArray{String,1,UInt32}:
 "x"
 "x"
 "y"
 "z"
 "y"
 "z"

julia> pool = classes(v[1])
3-element CategoricalArrays.CategoricalArray{String,1,UInt32}:
 "x"
 "y"
 "z"

julia> prob = [0.1, 0.2, 0.7] # "y"=>0.1, "x"=>0.2, "z"=>0.7
3-element Vector{Float64}:
 0.1
 0.2
 0.7

julia>  unf = UnivariateFinite(["y", "x", "z"], prob, pool=pool)
           UnivariateFinite{Multiclass{3}}
     ┌                                        ┐
   x ┤■■■■■■■■■■ 0.2
   y ┤■■■■■ 0.1
   z ┤■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 0.7
     └                                        ┘

julia> classes(unf) == pool
true
```
`"x"`, `"y"` and `"z"` are now assigned probabilities `0.2`, `0.1`, `0.7` respectively as expected.
Fixes issue #34
cc. @ablaom 