### PR TITLE
Make UnicodePlots a weak dependency (for julia > 1.9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         version:
           - '1.6'
           - '1' # automatically expands to the latest stable 1.x release of Julia.
-          - 'nightly'
+          - '1.9'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         version:
           - '1.6'
           - '1' # automatically expands to the latest stable 1.x release of Julia.
-          - '1.9'
+          - '~1.9.0-0'
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,12 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ScientificTypes = "321657f4-b219-11e9-178b-2701a2544e81"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
+[weakdeps]
+UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
+
+[extensions]
+UnivariateFiniteDisplayExt = "UnicodePlots"
+
 [compat]
 CategoricalArrays = "0.9, 0.10"
 Distributions = "0.25"

--- a/Project.toml
+++ b/Project.toml
@@ -32,6 +32,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
+UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [targets]
-test = ["Random", "StableRNGs", "Test", "FillArrays"]
+test = ["FillArrays", "Random", "StableRNGs", "Test", "UnicodePlots"]

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ this package is the class pool of a `CategoricalArray`:
 using CategoricalDistributions
 using CategoricalArrays
 import Distributions
+import UnicodePlots # for optional pretty display
 data = ["no", "yes", "no", "maybe", "maybe", "no",
        "maybe", "no", "maybe"] |> categorical
 julia> d = Distributions.fit(UnivariateFinite, data)

--- a/ext/UnivariateFiniteDisplayExt.jl
+++ b/ext/UnivariateFiniteDisplayExt.jl
@@ -1,0 +1,28 @@
+module UnivariateFiniteDisplayExt
+
+const MAX_NUM_LEVELS_TO_SHOW_BARS = 12
+
+using CategoricalDistributions
+import CategoricalArrays
+import UnicodePlots
+import ScientificTypes.Finite
+
+# The following is a specialization of a `show` method already in /src/ for the common
+# case of `Real` probabilities.
+function Base.show(io::IO, mime::MIME"text/plain",
+                   d::UnivariateFinite{<:Finite{K},V,R,P}) where {K,V,R,P<:Real}
+    show_bars = false
+    if K <= MAX_NUM_LEVELS_TO_SHOW_BARS &&
+        all(>=(0), values(d.prob_given_ref))
+        show_bars = true
+    end
+    show_bars || return show(io, d)
+    s = support(d)
+    x = string.(CategoricalArrays.DataAPI.unwrap.(s))
+    y = pdf.(d, s)
+    S = d.scitype
+    plt = UnicodePlots.barplot(x, y, title="UnivariateFinite{$S}")
+    show(io, mime, plt)
+end
+
+end

--- a/src/CategoricalDistributions.jl
+++ b/src/CategoricalDistributions.jl
@@ -13,10 +13,8 @@ using OrderedCollections
 using CategoricalArrays
 import Missings
 using Random
-using UnicodePlots
 
 const Dist = Distributions
-const MAX_NUM_LEVELS_TO_SHOW_BARS = 12
 
 import Distributions: pdf, logpdf, support, mode
 
@@ -34,5 +32,10 @@ export pdf, logpdf, support, mode
 
 # re-export from ScientificTypesBase:
 export Multiclass, OrderedFactor
+
+# for julia < 1.9
+if !isdefined(Base, :get_extension)
+  include("../ext/UnivariateFiniteDisplayExt.jl")
+end
 
 end

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -82,23 +82,6 @@ end
 Base.show(io::IO, mime::MIME"text/plain",
           d::UnivariateFinite) = show(io, d)
 
-# in common case of `Real` probabilities we can do a pretty bar plot:
-function Base.show(io::IO, mime::MIME"text/plain",
-                   d::UnivariateFinite{<:Finite{K},V,R,P}) where {K,V,R,P<:Real}
-    show_bars = false
-    if K <= MAX_NUM_LEVELS_TO_SHOW_BARS &&
-        all(>=(0), values(d.prob_given_ref))
-        show_bars = true
-    end
-    show_bars || return show(io, d)
-    s = support(d)
-    x = string.(CategoricalArrays.DataAPI.unwrap.(s))
-    y = pdf.(d, s)
-    S = d.scitype
-    plt = barplot(x, y, title="UnivariateFinite{$S}")
-    show(io, mime, plt)
-end
-
 show_prefix(u::UnivariateFiniteArray{S,V,R,P,1}) where {S,V,R,P} =
     "$(length(u))-element"
 show_prefix(u::UnivariateFiniteArray) = join(size(u),'x')

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -268,6 +268,20 @@ end
     # @test v ≈ v_close
 end
 
+function displays_okay(v) # `v` a "probability" vector
+    d = UnivariateFinite(v, pool=missing);
+    str = sprint(show, "text/plain", d)
+    contains(str, "UnivariateFinite{Multiclass{$(length(v))}}")
+end
+
+@testset "display" begin
+    @test displays_okay([0.3, 0.7])
+    @test displays_okay([5 + 3im, 4 - 7im])
+    using UnicodePlots
+    @test displays_okay([0.3, 0.7])
+    @test displays_okay([5 + 3im, 4 - 7im])
+end
+
 end # module
 
 true


### PR DESCRIPTION
Closes #49 

There is [an issue](https://github.com/JuliaLang/julia/issues/48774) with `@time_imports` on Julia 1.9, but here is a summary benchark (no pre-compilation) for Julia Version 1.9.0-beta4:

```julia
# before this PR:
julia> @time using CategoricalDistributions
  4.774755 seconds (9.20 M allocations: 591.403 MiB, 4.50% gc time, 3.52% compilation time: 87% of which was recompilation)
```

```julia
# after this PR
julia> @time using CategoricalDistributions
  1.684570 seconds (2.62 M allocations: 168.023 MiB, 3.60% gc time, 9.73% compilation time: 86% of which was recompilation)
```

This PR will not impact load times for julia < 1.9. 

I'd prefer not to add a temporary Requires.jl hack to address this. 

