### PR TITLE
Use @belapsed for performance measurements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,11 +28,12 @@ UnicodePlots = "2, 3"
 julia = "1.6"
 
 [extras]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [targets]
-test = ["FillArrays", "Random", "StableRNGs", "Test", "UnicodePlots"]
+test = ["BenchmarkTools", "FillArrays", "Random", "StableRNGs", "Test", "UnicodePlots"]

--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 UnivariateFiniteDisplayExt = "UnicodePlots"
 
 [compat]
+BenchmarkTools = "1.3.2"
 CategoricalArrays = "0.9, 0.10"
 Distributions = "0.25"
 Missings = "0.4, 1"

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -1,9 +1,14 @@
 module TestArithmetic
 
 using Test
+import BenchmarkTools: @belapsed
 using CategoricalDistributions
 using StableRNGs
 rng = StableRNG(123)
+
+macro belapsed1(ex)
+    :(@belapsed $ex seconds=1 evals=1)
+end
 
 L = ["yes", "no"]
 d1 = UnivariateFinite(L, rand(rng, 2), pool=missing)
@@ -46,27 +51,27 @@ fast = UnivariateFinite(L, P, pool=missing);
 
 @testset "performant arithmetic for UnivariateFiniteArray" begin
     @test pdf(slow + slow, L) == pdf(fast + fast, L)
-    t_slow = @elapsed @eval slow + slow
-    t_fast = @elapsed @eval fast + fast
+    t_slow = @belapsed1 $slow + $slow
+    t_fast = @belapsed1 $fast + $fast
     @test t_slow/t_fast > 10
 
     @test pdf(slow - slow, L) == pdf(fast - fast, L)
-    t_slow = @elapsed @eval slow - slow
-    t_fast = @elapsed @eval fast - fast
+    t_slow = @belapsed1 $slow - $slow
+    t_fast = @belapsed1 $fast - $fast
     @test t_slow/t_fast > 10
 
     @test pdf(42*slow, L) == pdf(42*fast, L)
     @test pdf(slow*42, L) == pdf(fast*42, L)
-    t_slow = @elapsed @eval 42*slow
-    t_fast = @elapsed @eval 42*fast
+    t_slow = @belapsed1 42*$slow
+    t_fast = @belapsed1 42*$fast
     @test t_slow/t_fast > 10
-    t_slow = @elapsed @eval slow*42
-    t_fast = @elapsed @eval fast*42
+    t_slow = @belapsed1 $slow*42
+    t_fast = @belapsed1 $fast*42
     @test t_slow/t_fast > 10
 
     @test pdf(slow/42, L) == pdf(fast/42, L)
-    t_slow = @elapsed @eval slow/42
-    t_fast = @elapsed @eval fast/42
+    t_slow = @belapsed1 $slow/42
+    t_fast = @belapsed1 $fast/42
     @test t_slow/t_fast > 10
 end
 


### PR DESCRIPTION
Add BenchmarkTools as test dependency.
Run performance tests for fast arithmetic for one second each to avoid spurious regressions.