### PR TITLE
Fix implementation of `rand`

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -248,7 +248,7 @@ which has cumulative probability vector `p_cumulative` (see
 
 """
 function _rand(rng, p_cumulative, R)
-    real_sample = Base.rand(rng)*p_cumulative[end]
+    real_sample = rand(rng)*p_cumulative[end]
     K = R(length(p_cumulative))
     index = K
     for i in R(2):R(K)

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -215,6 +215,8 @@ end
 """
     _cumulative(d::UnivariateFinite)
 
+**Private method.**
+
 Return the cumulative probability vector `C` for the distribution `d`,
 using only classes in the support of `d`, ordered according to the
 categorical elements used at instantiation of `d`. Used only to
@@ -238,13 +240,15 @@ end
 """
 _rand(rng, p_cumulative, R)
 
+**Private method.**
+
 Randomly sample the distribution with discrete support `R(1):R(n)`
 which has cumulative probability vector `p_cumulative` (see
 [`_cummulative`](@ref)).
 
 """
 function _rand(rng, p_cumulative, R)
-    real_sample = rand(rng)*p_cumulative[end]
+    real_sample = Base.rand(rng)*p_cumulative[end]
     K = R(length(p_cumulative))
     index = K
     for i in R(2):R(K)
@@ -261,10 +265,11 @@ function Base.rand(rng::AbstractRNG,
     p_cumulative = _cumulative(d)
     return Dist.support(d)[_rand(rng, p_cumulative, R)]
 end
+Base.rand(d::UnivariateFinite) = rand(Random.default_rng(), d)
 
 function Base.rand(rng::AbstractRNG,
                    d::UnivariateFinite{<:Any,<:Any,R},
-                   dim1::Int, moredims::Int...) where R # ref type
+                   dim1::Integer, moredims::Integer...) where R # ref type
     p_cumulative = _cumulative(d)
     A = Array{R}(undef, dim1, moredims...)
     for i in eachindex(A)
@@ -274,7 +279,8 @@ function Base.rand(rng::AbstractRNG,
     return broadcast(i -> support[i], A)
 end
 
-rng(d::UnivariateFinite, args...) = rng(Random.GLOBAL_RNG, d, args...)
+Base.rand(d::UnivariateFinite, dim1::Integer, moredims::Integer...) =
+    rand(Random.default_rng(), d, dim1, moredims...)
 
 function Dist.fit(d::Type{<:UnivariateFinite},
                            v::AbstractVector{C}) where C

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -300,24 +300,26 @@ end
     @test displays_okay([5 + 3im, 4 - 7im])
 end
 
-if VERSION >= v"1.7"
-    @testset "rand signatures" begin
-        d = UnivariateFinite(
-            ["maybe", "no", "yes"],
-            [0.5, 0.4, 0.1];
-            pool=missing,
-        )
+@testset "rand signatures" begin
+    d = UnivariateFinite(
+        ["maybe", "no", "yes"],
+        [0.5, 0.4, 0.1];
+        pool=missing,
+    )
 
-        Random.seed!(123)
-        samples = [rand(default_rng(), d) for i in 1:30]
-        Random.seed!(123)
-        @test [rand(d) for i in 1:30] == samples
+    # smoke test:
+    sampler = Random.Sampler(default_rng(), d, Val(1))
+    rand(default_rng(), sampler)
 
-        Random.seed!(123)
-        samples = rand(Random.default_rng(), d, 3, 5)
-        Random.seed!(123)
-        @test samples == rand(d, 3, 5)
-    end
+    Random.seed!(123)
+    samples = [rand(default_rng(), d) for i in 1:30]
+    Random.seed!(123)
+    @test [rand(d) for i in 1:30] == samples
+
+    Random.seed!(123)
+    samples = rand(Random.default_rng(), d, 3, 5)
+    Random.seed!(123)
+    @test samples == rand(d, 3, 5)
 end
 
 end # module

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -8,6 +8,7 @@ using StableRNGs
 import Random
 rng = StableRNG(123)
 using ScientificTypes
+import Random.default_rng
 
 import CategoricalDistributions: classes, ERR_NAN_FOUND
 
@@ -127,7 +128,7 @@ end
 @testset "broadcasting pdf over single UnivariateFinite object" begin
     d = UnivariateFinite(["a", "b"], [0.1, 0.9], pool=missing);
     @test pdf.(d, ["a", "b"]) == [0.1, 0.9]
-end 
+end
 
 @testset "constructor arguments not categorical values" begin
     @test_throws ArgumentError UnivariateFinite(Dict('f'=>0.7, 'q'=>0.2))
@@ -297,6 +298,26 @@ end
     using UnicodePlots
     @test displays_okay([0.3, 0.7])
     @test displays_okay([5 + 3im, 4 - 7im])
+end
+
+if VERSION >= v"1.7"
+    @testset "rand signatures" begin
+        d = UnivariateFinite(
+            ["maybe", "no", "yes"],
+            [0.5, 0.4, 0.1];
+            pool=missing,
+        )
+
+        Random.seed!(123)
+        samples = [rand(default_rng(), d) for i in 1:30]
+        Random.seed!(123)
+        @test [rand(d) for i in 1:30] == samples
+
+        Random.seed!(123)
+        samples = rand(Random.default_rng(), d, 3, 5)
+        Random.seed!(123)
+        @test samples == rand(d, 3, 5)
+    end
 end
 
 end # module


### PR DESCRIPTION
Closes #65. 

This PR also changes the behaviour of `rand(d, args...)` to use `default_rng` in place of
`GLOBAL_RNG`, mimicking changes made to Random in Julia 1.7. 

**edit**

No, rather we now address #65 by implementing `Random.Sampler(rng, ::UnivariateDistribution)` and `Random.rand(rng, sampler)` instead directly overloading each variant of `rand([rng, ], ::UnivariateDistribution, args...)`. This has the effect of *automatically* using `default_rng` as the default rng, instead of `GLOBAL_RNG`, because that how Random overloads `Base.rand`.
