### PR TITLE
Introduce optimizations to speed up `rand(d)`

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.5%

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,3 +3,6 @@ coverage:
     project:
       default:
         threshold: 0.5%
+    patch:
+      default:
+        target: 80%

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -80,8 +80,7 @@ end
 # not exported:
 sample_scitype(d::UnivariateFiniteUnion) = d.scitype
 
-CategoricalArrays.isordered(d::UnivariateFinite) = isordered(classes(d))
-CategoricalArrays.isordered(u::UnivariateFiniteArray) = isordered(classes(u))
+CategoricalArrays.isordered(d::UnivariateFiniteUnion) = isordered(classes(d))
 
 
 ## DISPLAY

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -1,6 +1,6 @@
 # not for export:
-const UnivariateFiniteUnion =
-    Union{UnivariateFinite, UnivariateFiniteArray}
+const UnivariateFiniteUnion{S,V,R,P} =
+    Union{UnivariateFinite{S,V,R,P}, UnivariateFiniteArray{S,V,R,P}}
 
 """
     classes(d::UnivariateFinite)
@@ -42,18 +42,34 @@ end
 raw_support(d::UnivariateFiniteUnion) = collect(keys(d.prob_given_ref))
 
 """
-    Dist.support(d::UnivariateFinite)
-    Dist.support(d::UnivariateFiniteArray)
+    Distributions.support(d::UnivariateFinite)
+    Distributions.support(d::UnivariateFiniteArray)
 
 Ordered list of classes associated with non-zero probabilities.
 
     v = categorical(["yes", "maybe", "no", "yes"])
     d = UnivariateFinite(v[1:2], [0.3, 0.7])
-    support(d) # CategoricalArray{String,1,UInt32}["maybe", "yes"]
+    Distributions.support(d) # CategoricalArray{String,1,UInt32}["maybe", "yes"]
 
 """
-Dist.support(d::UnivariateFiniteUnion) =
-    map(d.decoder, raw_support(d))
+Distributions.support(d::UnivariateFiniteUnion) = classes(d)[raw_support(d)]
+
+"""
+    fast_support(d::UnivariateFinite)
+
+Same as `Distributions.support(d)` except it returns a vector of `CategoricalValue`s,
+rather than a `CategoricalVector`. It executes faster, about five times faster for a
+three-class `UnivariateFinite` distribution.
+"""
+function fast_support(d::UnivariateFiniteUnion{S,V,R}) where {S,V,R}
+    raw_support = keys(d.prob_given_ref)
+    n = length(raw_support)
+    ret = Vector{CategoricalValue{V,R}}(undef, n)
+    for (i, ref) in enumerate(raw_support)
+        ret[i] = d.decoder(ref)
+    end
+    ret
+end
 
 # TODO: If I manually give a class zero probability, it will appear in
 # support, which is probably confusing. We may need two versions of
@@ -96,8 +112,8 @@ probability pairs.  Returns `false` otherwise.
 
 """
 function Base.isapprox(d1::UnivariateFinite, d2::UnivariateFinite; kwargs...)
-    support1 = Dist.support(d1)
-    support2 = Dist.support(d2)
+    support1 = fast_support(d1)
+    support2 = fast_support(d2)
     for c in support1
         c in support2 || return false
         isapprox(pdf(d1, c), pdf(d2, c); kwargs...) ||
@@ -107,8 +123,8 @@ function Base.isapprox(d1::UnivariateFinite, d2::UnivariateFinite; kwargs...)
 end
 function Base.isapprox(d1::UnivariateFiniteArray,
                        d2::UnivariateFiniteArray; kwargs...)
-    support1 = Dist.support(d1)
-    support2 = Dist.support(d2)
+    support1 = fast_support(d1)
+    support2 = fast_support(d2)
     for c in support1
         c in support2 || return false
         isapprox(pdf.(d1, c), pdf.(d2, c); kwargs...) ||
@@ -206,22 +222,18 @@ function throw_nan_error_if_needed(x)
     end
 end
 
-# mode(v::Vector{UnivariateFinite}) = mode.(v)
-# mode(u::UnivariateFiniteVector{2}) =
-#     [u.support[ifelse(s > 0.5, 2, 1)] for s in u.scores]
-# mode(u::UnivariateFiniteVector{C}) where {C} =
-#     [u.support[findmax(s)[2]] for s in eachrow(u.scores)]
+
+# # HELPERS FOR RAND
 
 """
     _cumulative(d::UnivariateFinite)
 
 **Private method.**
 
-Return the cumulative probability vector `C` for the distribution `d`,
-using only classes in the support of `d`, ordered according to the
-categorical elements used at instantiation of `d`. Used only to
-implement random sampling from `d`. We have `C[1] == 0` and `C[end] ==
-1`, assuming the probabilities have been normalized.
+Return the cumulative probability vector `C` for the distribution `d`, using only classes
+in `Distributions.support(d)`, ordered according to the categorical elements used at
+instantiation of `d`. Used only to implement random sampling from `d`. We have `C[1] == 0`
+and `C[end] == 1`, assuming the probabilities have been normalized.
 
 """
 function _cumulative(d::UnivariateFinite{S,V,R,P}) where {S,V,R,P<:Real}
@@ -260,16 +272,44 @@ function _rand(rng, p_cumulative, R)
     return index
 end
 
-Random.eltype(::Type{<:UnivariateFinite{<:Any,V}}) where V = V
+
+# # RAND
+
+Random.eltype(::Type{<:UnivariateFinite{S,V,R}}) where {S,V,R} =
+    CategoricalArrays.CategoricalValue{V,R}
 
 # The Sampler hook into Random's API is discussed in the Julia documentation, in the
 # Standard Library section on Random.
+
+
+## Single samples
+
+Random.Sampler(::AbstractRNG, d::UnivariateFinite, ::Val{1}) = Random.SamplerTrivial(d)
+
+function Base.rand(
+    rng::AbstractRNG,
+    sampler::Random.SamplerTrivial{<:UnivariateFinite{<:Any,<:Any,<:Any,P}},
+    ) where P
+
+    d = sampler[]
+    u = rand(rng)
+
+    total = zero(P)
+    for (i, prob) in enumerate(values(d.prob_given_ref))
+        total += prob
+        u <= total && return fast_support(d)[i]
+    end
+end
+
+
+## Multiple samples
+
 function Random.Sampler(
     ::AbstractRNG,
     d::UnivariateFinite,
     ::Random.Repetition,
     )
-    data = (_cumulative(d), Dist.support(d))
+    data = (_cumulative(d), fast_support(d))
     Random.SamplerSimple(d, data)
 end
 
@@ -280,6 +320,9 @@ function Base.rand(
     p_cumulative, support = sampler.data
     return support[_rand(rng, p_cumulative, R)]
 end
+
+
+## FIT
 
 function Dist.fit(d::Type{<:UnivariateFinite},
                            v::AbstractVector{C}) where C


### PR DESCRIPTION
Addresses #64. 

Calling `rand(d)` for three-class `UnivariateFinite`, `d`, is now about 6 times slower
than `Distributions.Categorical`, instead of 80 times slower.

**edit** After further optimisation (@OkonSamuel) we are only 1.3 times slower!

The speed up has been obtained by:

- removing precomputation of CDF for single-sampling (minor speed up) 

- replacing `support(d)` with an optimized version `fast_support(d)` that does not collect
the output into a new `CategoricalArray`, but rather returns a raw vector of
`CategoricalValue`s.

I'm doubtful further significant speed-up is possible without a substantial redesign, such
as replacing the ref-based dictionaries (ref = CategoricalArray reference value) with
value-based dictionaries. This might have a performance impact on other functionality.

```julia
using Distributions
using CategoricalDistributions
using BenchmarkTools

categ = Distributions.Categorical([0.5, 0.4, 0.1])
d = UnivariateFinite(["maybe", "no", "yes"], [0.5, 0.4, 0.1]; pool=missing)

@btime rand($categ) # 11.6 ns
@btime rand($d) # 60.5; formerly 855 ns

julia> versioninfo()
Julia Version 1.9.1
Commit 147bdf428cd (2023-06-07 08:27 UTC)
Platform Info:
  OS: macOS (x86_64-apple-darwin22.4.0)
  CPU: 12 × Intel(R) Core(TM) i7-8850H CPU @ 2.60GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-14.0.6 (ORCJIT, skylake)
  Threads: 5 on 12 virtual cores
```
