### PR TITLE
allow dispatch on mixed number types for + and -

### DIFF
--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -9,7 +9,12 @@ import Base: +, *, /, -
 pdf_matrix(d::UnivariateFinite, L) = pdf.(d, L)
 pdf_matrix(d::AbstractArray{<:UnivariateFinite}, L) = pdf(d, L)
 
-function +(d1::U, d2::U) where U <: SingletonOrArray
+function +(d1::UnivariateFinite{S, V}, d2::UnivariateFinite{S, V}) where {S, V}
+    L = classes(d1)
+    L == classes(d2) || throw(ERR_DIFFERENT_SAMPLE_SPACES)
+    return UnivariateFinite(L, pdf_matrix(d1, L) + pdf_matrix(d2, L))
+end
+function +(d1::UnivariateFiniteArray{S, V}, d2::UnivariateFiniteArray{S, V}) where {S, V}
     L = classes(d1)
     L == classes(d2) || throw(ERR_DIFFERENT_SAMPLE_SPACES)
     return UnivariateFinite(L, pdf_matrix(d1, L) + pdf_matrix(d2, L))
@@ -27,7 +32,12 @@ end
 -(d::UnivariateFinite) = _minus(d, UnivariateFinite)
 -(d::UnivariateFiniteArray) = _minus(d, UnivariateFiniteArray)
 
-function -(d1::U, d2::U) where U <: SingletonOrArray
+function -(d1::UnivariateFinite{S, V}, d2::UnivariateFinite{S, V}) where {S, V}
+    L = classes(d1)
+    L == classes(d2) || throw(ERR_DIFFERENT_SAMPLE_SPACES)
+    return UnivariateFinite(L, pdf_matrix(d1, L) - pdf_matrix(d2, L))
+end
+function -(d1::UnivariateFiniteArray{S, V}, d2::UnivariateFiniteArray{S, V}) where {S, V}
     L = classes(d1)
     L == classes(d2) || throw(ERR_DIFFERENT_SAMPLE_SPACES)
     return UnivariateFinite(L, pdf_matrix(d1, L) - pdf_matrix(d2, L))

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -13,7 +13,7 @@ end
 L = ["yes", "no"]
 d1 = UnivariateFinite(L, rand(rng, 2), pool=missing)
 d2 = UnivariateFinite(L, rand(rng, 2), pool=missing)
-df32 = UnivariateFinite(L, rand(Float32, rng, 2), pool=missing)
+df32 = UnivariateFinite(L, rand(rng, Float32, 2), pool=missing)
 
 @testset "arithmetic" begin
 

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -13,6 +13,7 @@ end
 L = ["yes", "no"]
 d1 = UnivariateFinite(L, rand(rng, 2), pool=missing)
 d2 = UnivariateFinite(L, rand(rng, 2), pool=missing)
+df32 = UnivariateFinite(L, rand(Float32, rng, 2), pool=missing)
 
 @testset "arithmetic" begin
 
@@ -20,7 +21,9 @@ d2 = UnivariateFinite(L, rand(rng, 2), pool=missing)
     for op in [:+, :-]
         quote
             s = $op(d1, d2 )
+            s2 = $op(d1, df32 )
             @test $op(pdf.(d1, L), pdf.(d2, L)) ≈ pdf.(s, L)
+            @test $op(pdf.(d1, L), pdf.(df32, L)) ≈ pdf.(s2, L)
         end |> eval
     end
 


### PR DESCRIPTION
`+` and `-` on UnivariateFinite and UniveriateFiniteArrays currently fails if real number types mixed, even if the classes are identical. This PR allows this.